### PR TITLE
Add auto-merge workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yaml
+++ b/.github/workflows/auto-merge-dependabot.yaml
@@ -1,0 +1,20 @@
+name: Auto-merge Dependabot PRs
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  pr-auto-approve:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.repository == 'mmuffins/artist-resolver-frontend'
+      && contains(github.event.pull_request.labels.*.name, 'github_actions')
+    steps:
+      - name: Merge PR
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This workflow automatically merges pull requests created by Dependabot if they have the 'github_actions' label.